### PR TITLE
fix: set resource Status using patch instead of update

### DIFF
--- a/internal/controller/rrset_controller.go
+++ b/internal/controller/rrset_controller.go
@@ -120,6 +120,9 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// Set OwnerReference
 	if err := r.ownObject(ctx, zone, rrset); err != nil {
+		if errors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -198,6 +201,7 @@ func (r *RRsetReconciler) createOrUpdateExternalResources(ctx context.Context, z
 	return true, nil
 }
 
+// ownObject set the owner reference on RRset
 func (r *RRsetReconciler) ownObject(ctx context.Context, zone *dnsv1alpha1.Zone, rrset *dnsv1alpha1.RRset) error {
 	err := ctrl.SetControllerReference(zone, rrset, r.Scheme)
 	if err != nil {

--- a/internal/controller/rrset_controller.go
+++ b/internal/controller/rrset_controller.go
@@ -123,15 +123,15 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	// Updating Status
-	// This update is very important:
+	// This Patch is very important:
 	// When an update on RRSet is applied, a reconcile event is triggered on Zone
 	// But, sometimes, Zone reonciliation finish before RRSet update is applied
 	// In that case, the Serial in Zone Status is false
 	// This update permits triggering a new event after RRSet update applied
+	original := rrset.DeepCopy()
 	rrset.Status.LastUpdateTime = lastUpdateTime
-	if err := r.Status().Update(ctx, rrset); err != nil {
-		log.Error(err, "unable to update RRSet status")
+	if err := r.Status().Patch(ctx, rrset, client.MergeFrom(original)); err != nil {
+		log.Error(err, "unable to patch RRSet status")
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Resource .Status should be updated using Patch() instead of Update().

Also, if a conflict is detected, it means the original object has been changed in etcd and we're working on an outdated object. So, it's probably better to requeue the reconciliation.