### PR TITLE
test: improve test dealing with timezone

### DIFF
--- a/internal/controller/zone_controller_test.go
+++ b/internal/controller/zone_controller_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Zone Controller", func() {
 			Expect(getMockedNameservers(resourceName)).To(Equal(resourceNameservers), "Nameservers should be equal")
 			Expect(getMockedCatalog(resourceName)).To(Equal(resourceCatalog), "Catalog should be equal")
 			Expect(zone.GetFinalizers()).To(ContainElement(FINALIZER_NAME), "Zone should contain the finalizer")
-			Expect(fmt.Sprintf("%d", *(zone.Status.Serial))).To(Equal(fmt.Sprintf("%s01", time.Now().Format("20060102"))), "Serial should be YYYYMMDD01")
+			Expect(fmt.Sprintf("%d", *(zone.Status.Serial))).To(Equal(fmt.Sprintf("%s01", time.Now().UTC().Format("20060102"))), "Serial should be YYYYMMDD01")
 		})
 	})
 


### PR DESCRIPTION
tests failed because of timezone (bad serial calculation) 