### PR TITLE
ci(build): fix Trivy TOOMANYREQUESTS error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,12 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
         if: github.event_name != 'pull_request'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
           image-ref: ${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
-          format: 'table'
-          exit-code: '1'
+          format: "table"
+          exit-code: "1"
           ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"


### PR DESCRIPTION
This PR aims to address the current rate-limiting issue that prevents Trivy to retrieve the database.

```
Running Trivy with options: trivy image ghcr.io/mydoomfr/powerdns-operator:main
2024-10-29T16:05:02Z	INFO	[vulndb] Need to update DB
2024-10-29T16:05:02Z	INFO	[vulndb] Downloading vulnerability DB...
2024-10-29T16:05:02Z	INFO	[vulndb] Downloading artifact...	repo="ghcr.io/aquasecurity/trivy-db:2"
2024-10-29T16:05:02Z	ERROR	[vulndb] Failed to download artifact	repo="ghcr.io/aquasecurity/trivy-db:2" err="OCI repository error: 1 error occurred:\n\t* GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 571.072µs, allowed: 44000/minute\n\n"
2024-10-29T16:05:02Z	FATAL	Fatal error	init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from any source
Error: Process completed with exit code 1.
```

See https://github.com/aquasecurity/trivy-action/issues/389