### PR TITLE
fix: golangci-lint change its configuration file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request: {}
 
 env:
-  GOLANGCI_VERSION: 'v1.64.6'
+  GOLANGCI_VERSION: 'v1.64.8'
   KUBERNETES_VERSION: '1.31.0'
 
 permissions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,7 @@ run:
   timeout: 5m
   allow-parallel-runners: true
 
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
-  exclude-dirs:
-    - .git
-    - .github
-    - test
-
 linters:
-  disable-all: true
   enable:
     - dupl
     - errcheck
@@ -43,3 +23,23 @@ linters:
     - unconvert
     - unparam
     - unused
+  exclusions:
+    warn-unused: false
+    rules:
+      - path: "api/*"
+        linters:
+          - lll
+      - path: "internal/*"
+        linters:
+          - dupl
+          - lll
+      - path: _test\.go
+        linters:
+          - gocyclo
+          - errcheck
+          - dupl
+          - gosec
+    paths:
+      - .git
+      - .github
+      - test

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.2
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.64.6
+GOLANGCI_LINT_VERSION ?= v1.64.8
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.


### PR DESCRIPTION
Multiple changes on configuration files
```
jsonschema: "issues" does not validate with "/properties/issues/additionalProperties": additional properties 'exclude-use-default', 'exclude-rules', 'exclude-dirs' not allowed
jsonschema: "linters" does not validate with "/properties/linters/additionalProperties": additional properties 'disable-all' not allowed
```